### PR TITLE
ppcie attestation support

### DIFF
--- a/vllm-proxy/docker/Dockerfile
+++ b/vllm-proxy/docker/Dockerfile
@@ -3,6 +3,10 @@ FROM vllm/vllm-openai:v0.9.1
 
 # Install dependencies
 WORKDIR /tmp
+
+# Install packages via requirements.txt instead of poetry
+# because of nv-ppcie-verifier requires some old version packages,
+# which is not compatible with lots of current dependencies.
 COPY src/requirements.txt ./
 RUN pip install --no-cache-dir --upgrade -r requirements.txt \
     && rm -rf requirements.txt

--- a/vllm-proxy/docker/Dockerfile
+++ b/vllm-proxy/docker/Dockerfile
@@ -1,11 +1,10 @@
-FROM python:3.11
+# GPU quote requires pynvml, which requires cuda, so use vllm image instead of python3
+FROM vllm/vllm-openai:v0.9.1
 
 # Install dependencies
 WORKDIR /tmp
-RUN pip install poetry==1.8.5
-COPY ./pyproject.toml ./poetry.lock* ./
-RUN poetry export -f requirements.txt --output requirements.txt --without-hashes \
-    && pip install --no-cache-dir --upgrade -r requirements.txt \
+COPY src/requirements.txt ./
+RUN pip install --no-cache-dir --upgrade -r requirements.txt \
     && rm -rf requirements.txt
 
 # Copy source code

--- a/vllm-proxy/pyproject.toml
+++ b/vllm-proxy/pyproject.toml
@@ -16,7 +16,7 @@ cachetools = "^5.5.0"
 dstack-sdk = "^0.1.5"
 cryptography = "^43.0.1"
 redis = "^5.2.1"
-nv-local-gpu-verifier = "^2.3.0"
+nv-ppcie-verifier = "^1.5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"

--- a/vllm-proxy/src/app/quote/quote.py
+++ b/vllm-proxy/src/app/quote/quote.py
@@ -3,11 +3,13 @@ import json
 import os
 
 import eth_utils
+import pynvml
 import web3
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from dstack_sdk import TappdClient
 from eth_account.messages import encode_defunct
+from nv_attestation_sdk import attestation
 from verifier import cc_admin
 
 ED25519 = "ed25519"
@@ -27,7 +29,7 @@ class Quote:
         self.raw_acct = None
         self.ed25519_key = None
 
-    def init(self, force=False):
+    def init(self, force=False) -> dict:
         """
         Initialize the quote object.
         If the signing address is already set, it will not be re-initialized.
@@ -44,15 +46,46 @@ class Quote:
             raise ValueError("Unsupported signing method")
 
         self.intel_quote = self.get_quote(self.public_key)
-
-        gpu_evidence_list = cc_admin.collect_gpu_evidence_remote(self.public_key)
-        self.nvidia_payload = self.build_payload(self.public_key, gpu_evidence_list)
+        self.nvidia_payload = self.get_gpu_payload(self.public_key)
 
         return dict(
             intel_quote=self.intel_quote,
             nvidia_payload=self.nvidia_payload,
             signing_address=self.signing_address,
         )
+
+    def get_gpu_payload(self, public_key: str) -> str:
+        gpu_evidence_list = []
+        try:
+            pynvml.nvmlInit()
+            device_count = pynvml.nvmlDeviceGetCount()
+            if device_count == 1:
+                gpu_evidence_list = cc_admin.collect_gpu_evidence_remote(public_key)
+            else:
+                switch_attestation_mode = "REMOTE"
+                switch_attester = attestation.Attestation()
+                switch_attester.set_name("HOPPER")
+                switch_attester.set_nonce(public_key)
+                switch_attester.set_claims_version("2.0")
+                switch_attester.set_ocsp_nonce_disabled(True)
+                switch_attester.add_verifier(
+                    dev=attestation.Devices.GPU,
+                    env=attestation.Environment[switch_attestation_mode],
+                    url=None,
+                    evidence="",
+                )
+                gpu_evidence_list = switch_attester.get_evidence(
+                    options={"ppcie_mode": False}
+                )
+        except pynvml.NVMLError as error:
+            raise Exception(f"CUDA Error: {error}")
+        finally:
+            pynvml.nvmlShutdown()
+
+        if len(gpu_evidence_list) == 0:
+            raise Exception("No GPU evidence found")
+
+        return self.build_payload(public_key, gpu_evidence_list)
 
     def init_ed25519(self):
         # Generate Ed25519 key pair

--- a/vllm-proxy/src/requirements.txt
+++ b/vllm-proxy/src/requirements.txt
@@ -1,0 +1,10 @@
+fastapi[standard]==0.115.6
+uvicorn[standard]==0.34.0
+web3==7.6.0
+eth-account==0.13.4
+eth-utils==5.1.0
+cachetools==5.5.0
+dstack-sdk==0.1.5
+cryptography==43.0.1
+redis==5.2.1
+nv-ppcie-verifier==1.5.0


### PR DESCRIPTION
- Add NVIDIA ppcie attestation support via the package of `nv-ppcie-verifier`
- Change vllm-proxy base docker image to vllm/vllm-openai, because `pynvml` requires cuda
