### PR TITLE
fix: include text/event-stream in response content-type

### DIFF
--- a/vllm-proxy/src/app/api/v1/openai.py
+++ b/vllm-proxy/src/app/api/v1/openai.py
@@ -103,6 +103,7 @@ async def stream_vllm_response(
     return StreamingResponse(
         generate_stream(response),
         background=BackgroundTasks([response.aclose, client.aclose]),
+        media_type="text/event-stream",
     )
 
 


### PR DESCRIPTION
We encountered an issue that the chat completion response header doesn't contain `content-type: text/event-stream` to explicitly tell the client that it's using SSE.

This PR is proposed to fix this issue by specifying `text/event-stream` media type argument in [`StreamingResponse`](https://github.com/encode/starlette/blob/6ee94f2cac955eeae68d2898a8dec8cf17b48736/starlette/responses.py#L220). Please help review.

#### Response without `content-type: text/event-stream` header

```bash
curl -i http://<base-url>/v1/chat/completions \
  -H "Authorization: Bearer <API Key>" \
  -H "Content-Type: application/json" \
  -d '{
    "stream": "true",
    "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
    "messages": [{"role": "user", "content": "How are you?"}]
  }'


HTTP/1.1 200 OK
date: Fri, 01 Aug 2025 14:13:03 GMT
server: uvicorn
transfer-encoding: chunked
```

#### Response with `content-type: text/event-stream` header
```
curl -i https://api.redpill.ai/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <API Key>" \
  -d '{
    "stream": "true",
    "model": "phala/llama-3.1-70b-instruct",
    "messages": [
      {"role": "user", "content": "How are you?"}
    ]
  }'


HTTP/2 200 
access-control-allow-origin: *
alt-svc: h3=":443"; ma=2592000
content-type: text/event-stream
date: Fri, 01 Aug 2025 14:09:07 GMT
server: Caddy
```

