### PR TITLE
Check if message[tool_calls] is None, therefore len() could be fatal

### DIFF
--- a/vllm-proxy/src/app/api/v1/openai.py
+++ b/vllm-proxy/src/app/api/v1/openai.py
@@ -158,7 +158,7 @@ def strip_empty_tool_calls(payload: dict) -> dict:
     filtered_messages = []
     for message in payload["messages"]:
         # If the message has tool_calls, filter out empty ones
-        if "tool_calls" in message and len(message["tool_calls"]) == 0:
+        if "tool_calls" in message and message["tool_calls"] is not None and len(message["tool_calls"]) == 0:
             del message["tool_calls"]
         filtered_messages.append(message)
 


### PR DESCRIPTION
Former logic only checks `len(message[tool_calls])` without None check, leading to some error