### PR TITLE
Fix `data: [DONE]` not parsing well

### DIFF
--- a/vllm-proxy/src/app/api/v1/openai.py
+++ b/vllm-proxy/src/app/api/v1/openai.py
@@ -70,7 +70,7 @@ async def stream_vllm_response(
             # Extract the cache key (data.id) from the first chunk
             if not chat_id:
                 data = chunk.strip("data: ").strip()
-                if not data:
+                if not data or data == "[DONE]":
                     continue
                 try:
                     chunk_data = json.loads(data)


### PR DESCRIPTION
Handle both `data is None` and `data is [DONE]` for streaming cases