### PR TITLE
Add libnvidia-ptxjitcompiler to installation process

### DIFF
--- a/meta-dstack-nvidia/meta-nvidia/recipes-graphics/nvidia/nvidia-libs.inc
+++ b/meta-dstack-nvidia/meta-nvidia/recipes-graphics/nvidia/nvidia-libs.inc
@@ -37,6 +37,7 @@ do_install:append() {
     addlib libnvcuvid
     addlib libnvidia-pkcs11-openssl3
     addlib libnvidia-pkcs11
+    addlib libnvidia-ptxjitcompiler
 
     cp ${NVIDIA_SRC}/libnvidia-api.so.1 ${D}${libdir}/
     ln -sf libnvidia-api.so.1 ${D}${libdir}/libnvidia-api.so


### PR DESCRIPTION
This fixes error we've been getting with vLLM v0.10.2.