### PR TITLE
Add host IP to the list of insecure docker registries.

### DIFF
--- a/meta-dstack-nvidia/meta-dstack/recipes-core/dstack-guest/files/docker-daemon.json
+++ b/meta-dstack-nvidia/meta-dstack/recipes-core/dstack-guest/files/docker-daemon.json
@@ -1,4 +1,7 @@
 {
+  "insecure-registries": [
+      "10.0.2.2:5000"
+  ],
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "100m",


### PR DESCRIPTION
This allows to use a local docker registry in the docker compose file and speed up re-deployment times.